### PR TITLE
Remove troublesome comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
     "pki"
   ],
   "dependencies" : {
-    "//": ["Pinned version to avoid breaking us when something changes",
-    "we have twice had something break, so this way we control it.",
-    "To test with the latest development version, use this:",
-    "git://github.com/digitalbazaar/forge.git"],
     "node-forge": "0.3.0"
   },
   "license": "BSD"


### PR DESCRIPTION
[Yarn is incompatible](https://github.com/yarnpkg/yarn/issues/2484) with `package.json` comments like this. Until it's worked out, I see vast benefits in removing the comment entirely.